### PR TITLE
Elasticsearch für Datenzugriffe verwenden

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.6.7-slim-jessie
 
+
 ADD requirements.txt /
+RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
 
 ADD jsonhandler.py /

--- a/main.py
+++ b/main.py
@@ -48,24 +48,6 @@ def flatten(d, parent_key='', sep='.'):
     return dict(items)
 
 
-def get_compact_results():
-    query = client.query(kind=spider_results_kind,
-                         order=['-created'],
-                         )
-
-    out = []
-    for entity in query.fetch(eventual=True):
-        created = convert_datastore_datetime(entity.get('created'))
-        
-        out.append({
-            'input_url': entity.key.name,
-            'created': created.isoformat(),
-            'meta': entity.get('meta'),
-            'score': entity.get('score'),
-        })
-    return out
-
-
 def simplify_rating(d):
     """
     Removes some keys from a flattened rating dict
@@ -223,7 +205,6 @@ class Index(object):
             "endpoints": [
                 "/api/v1/spider-results/last-updated/",
                 "/api/v1/spider-results/table/",
-                "/api/v1/spider-results/compact/",
                 "/api/v1/spider-results/site",
                 "/api/v1/screenshots/site",
             ]

--- a/main.py
+++ b/main.py
@@ -122,17 +122,14 @@ class LastUpdated(object):
         """
         Informs about the most recent update to the spider results data
         """
-        query = datastore_client.query(kind=spider_results_kind,
-                                       order=['-created'],
-                                       projection=['created'])
-        items = list(query.fetch(limit=1, eventual=True))
-        ts = int(items[0].get('created')) / 1000000
-        dt = datetime.utcfromtimestamp(ts).isoformat()
+        res = es.search(index=es_index_name,
+            filter_path=['hits.hits._source.created'],
+            body={"query": {"match_all": {}}},
+            sort='created:desc',
+            size=1)
 
-        maxage = 60 * 60  # one hour in seconds
-        resp.cache_control = ["max_age=%d" % maxage]
         resp.media = {
-            "last_updated": dt
+            "last_updated": res['hits']['hits'][0]['_source']['created']
         }
 
 

--- a/main.py
+++ b/main.py
@@ -175,16 +175,18 @@ class SiteDetails(object):
                                'Bad request',
                                'The parameter url must not be empty')
 
-        key = datastore_client.key(spider_results_kind, req.get_param('url'))
-        entity = datastore_client.get(key)
+        entity = es.get(index=es_index_name, doc_type=es_doc_type, id=url)
         if entity is None:
             raise falcon.HTTPError(falcon.HTTP_404,
                                'Not found',
                                'A site with this URL does not exist')
 
-        maxage = 24 * 60 * 60  # 24 hours in seconds
+        if 'url' in entity['_source']:
+            del entity['_source']['url']
+
+        maxage = 5 * 60  # 5 minutes in seconds
         resp.cache_control = ["max_age=%d" % maxage]
-        resp.media = dict(entity)
+        resp.media = entity['_source']
 
 
 class SiteScreenshots(object):

--- a/main.py
+++ b/main.py
@@ -219,7 +219,7 @@ class Index(object):
             "url": "https://github.com/netzbegruenung/green-spider-api",
             "endpoints": [
                 "/api/v1/spider-results/last-updated/",
-                "/api/v1/spider-results/big/",
+                "/api/v1/spider-results/table/",
                 "/api/v1/spider-results/compact/",
                 "/api/v1/spider-results/site",
                 "/api/v1/screenshots/site",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astroid==2.0.4
 cachetools==2.1.0
 certifi==2018.10.15
 chardet==3.0.4
+elasticsearch==6.3.1
 falcon==1.4.1
 google-api-core==1.5.1
 google-auth==1.5.1
@@ -15,8 +16,8 @@ isort==4.3.4
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
 protobuf==3.6.1
-pyasn1==0.4.4
 pyasn1-modules==0.2.2
+pyasn1==0.4.4
 pylint==2.1.1
 python-mimeparse==1.6.0
 pytz==2018.7


### PR DESCRIPTION
Für https://github.com/netzbegruenung/green-spider/issues/107

Diese Änderungen bewirken, dass Datenzugriffe der Webapp nicht mehr vom Google Datastore geladen werden müssen, sondern schneller und günstiger aus der lokalen Elasticsearch.