### PR TITLE
Add CSV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Gibt den Zeitpunkt der letzten Aktualisierung der Spider-Ergebnisse zurück.
 
 Gibt Ergebnisse für alle Sites in einem tabellenfreundlichen Format aus.
 
+Wenn per `Accept`-Header der Typ `text/csv` angefordert wird, erfolgt die Ausgabe
+im CSV-Format. Ansonsten wird JSON ausgegeben.
+
 ```json
 [
   {


### PR DESCRIPTION
Fixes https://github.com/netzbegruenung/green-spider/issues/119

Mit diesem PR erlaubt der API Enpunkt `GET /api/v1/spider-results/table/` wahlweise die Ausgabe von CSV oder JSON (vormals nur JSON).

Beispiel:

```nohighlight
curl -sS -H "Accept: text/csv" \
  https://green-spider.netzbegruenung.de/api/v1/spider-results/table/ > results.csv
```